### PR TITLE
feat(bots): Bot balance order preference

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -8,37 +8,35 @@ import (
 )
 
 type bot struct {
-	name      string
-	logger    *zap.Logger
-	fulfiller *orderFulfiller
-	newOrders chan []*demandOrder
-	failedCh  chan<- []string
+	name   string
+	logger *zap.Logger
+	*orderFulfiller
+	newOrders     chan []*demandOrder
+	unfulfilledCh chan<- []string
 }
 
 func newBot(
 	name string,
 	fulfiller *orderFulfiller,
-	newOrders chan []*demandOrder,
 	failedCh chan<- []string,
 	logger *zap.Logger,
 ) *bot {
 	return &bot{
-		name:      name,
-		fulfiller: fulfiller,
-		newOrders: newOrders,
-		failedCh:  failedCh,
-		logger:    logger.With(zap.String("name", name)),
+		name:           name,
+		orderFulfiller: fulfiller,
+		newOrders:      make(chan []*demandOrder),
+		unfulfilledCh:  failedCh,
+		logger:         logger.With(zap.String("name", name)),
 	}
 }
 
 func (b *bot) start(ctx context.Context) error {
-	balances, err := b.fulfiller.accountSvc.getAccountBalances(ctx)
-	if err != nil {
+	if err := b.accountSvc.refreshBalances(ctx); err != nil {
 		return fmt.Errorf("failed to get account balances: %w", err)
 	}
-	b.logger.Info("starting bot...", zap.String("balances", balances.String()))
+	b.logger.Info("starting bot...", zap.String("balances", b.accountSvc.balances.String()))
 
 	// start order fulfiller
-	b.fulfiller.fulfillOrders(ctx, b.newOrders, b.failedCh)
+	b.fulfillOrders(ctx, b.newOrders, b.unfulfilledCh)
 	return nil
 }

--- a/cmd.go
+++ b/cmd.go
@@ -73,6 +73,11 @@ var startCmd = &cobra.Command{
 			log.Fatalf("failed to create order client: %v", err)
 		}
 
+		if config.Bots.NumberOfBots == 0 {
+			log.Println("no bots to start")
+			return
+		}
+
 		if err := oc.start(cmd.Context()); err != nil {
 			log.Fatalf("failed to start order client: %v", err)
 		}

--- a/config.go
+++ b/config.go
@@ -21,6 +21,7 @@ type Config struct {
 	OrderRefreshInterval         time.Duration `mapstructure:"order_refresh_interval"`
 	OrderCleanupInterval         time.Duration `mapstructure:"order_cleanup_interval"`
 	DisputePeriodRefreshInterval time.Duration `mapstructure:"dispute_period_refresh_interval"`
+	IndexerURL                   string        `mapstructure:"indexer_url"`
 
 	Whale whaleConfig `mapstructure:"whale"`
 	Bots  botConfig   `mapstructure:"bots"`
@@ -53,13 +54,14 @@ type slackConfig struct {
 
 const (
 	defaultNodeAddress       = "http://localhost:36657"
+	defaultIndexerURL        = "http://44.206.211.230:3000/"
 	hubAddressPrefix         = "dym"
 	pubKeyPrefix             = "pub"
 	defaultLogLevel          = "info"
 	defaultGasLimit          = 300000
-	defaultGasDenom          = "adym"
-	defaultGasFees           = "100000000000000000" + defaultGasDenom
-	defaultMinimumGasBalance = "40000000000" + defaultGasDenom
+	defaultHubDenom          = "adym"
+	defaultGasFees           = "100000000000000000" + defaultHubDenom
+	defaultMinimumGasBalance = "40000000000" + defaultHubDenom
 	testKeyringBackend       = "test"
 
 	botNamePrefix                       = "bot-"
@@ -73,7 +75,7 @@ const (
 	defaultDisputePeriodRefreshInterval = 10 * time.Hour
 )
 
-var defaultBalanceThresholds = map[string]string{defaultGasDenom: "1000000000000"}
+var defaultBalanceThresholds = map[string]string{defaultHubDenom: "1000000000000"}
 
 func initConfig() {
 	// Set default values
@@ -104,6 +106,7 @@ func initConfig() {
 	viper.SetDefault("slack.enabled", false)
 	viper.SetDefault("slack.app_token", "<your-slack-app-token>")
 	viper.SetDefault("slack.channel_id", "<your-slack-channel-id>")
+	viper.SetDefault("indexer_url", defaultIndexerURL)
 
 	viper.SetConfigType("yaml")
 	if cfgFile != "" {

--- a/denom.go
+++ b/denom.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/cosmos/ibc-go/v6/modules/apps/transfer/types"
+
+	"github.com/dymensionxyz/cosmosclient/cosmosclient"
+)
+
+type denomFetcher struct {
+	sync.Mutex
+	pathMap map[string]string
+	client  cosmosclient.Client
+}
+
+func newDenomFetcher(client cosmosclient.Client) *denomFetcher {
+	return &denomFetcher{
+		pathMap: make(map[string]string),
+		client:  client,
+	}
+
+}
+
+func (d *denomFetcher) getDenomFromPath(ctx context.Context, path, destChannel string) (string, error) {
+	zeroChannelPrefix := "transfer/channel-0/"
+
+	// Remove "transfer/channel-0/" prefix if it exists
+	path = strings.TrimPrefix(path, zeroChannelPrefix)
+
+	if path == defaultHubDenom {
+		return defaultHubDenom, nil
+	}
+
+	// for denoms other than adym we should have a full path
+	// in order to be albe to derive the ibc denom hash
+	if !strings.Contains(path, "channel-") {
+		path = fmt.Sprintf("transfer/%s/%s", destChannel, path)
+	}
+
+	d.Lock()
+	defer d.Unlock()
+
+	denom, ok := d.pathMap[path]
+	if ok {
+		return denom, nil
+	}
+
+	queryClient := types.NewQueryClient(d.client.Context())
+
+	req := &types.QueryDenomHashRequest{
+		Trace: path,
+	}
+
+	res, err := queryClient.DenomHash(ctx, req)
+	if err != nil {
+		return "", fmt.Errorf("failed to query denom hash: %w", err)
+	}
+
+	ibcDenom := fmt.Sprintf("ibc/%s", res.Hash)
+
+	d.pathMap[path] = ibcDenom
+
+	return ibcDenom, nil
+}


### PR DESCRIPTION
This improves the way orders are assigned to bots: the bot with the least missing funds for fulfilling an order will be chosen first. So if it has enough funds it will fulfill it, if it is missing funds, at least it's the one that misses the least, which means the least amount to top-up of all bots (assuming it didn't spend funds on another order in parallel).

This brings some efficiency and decreases fragmentation of funds.