### PR TITLE
fix: default min gas balance should be bigger than gas fees

### DIFF
--- a/config.go
+++ b/config.go
@@ -5,11 +5,10 @@ import (
 	"time"
 
 	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/dymensionxyz/cosmosclient/cosmosclient"
 	"github.com/ignite/cli/ignite/pkg/cosmosaccount"
 	"github.com/mitchellh/go-homedir"
 	"github.com/spf13/viper"
-
-	"github.com/dymensionxyz/cosmosclient/cosmosclient"
 )
 
 type Config struct {
@@ -70,7 +69,7 @@ const (
 	defaultGasLimit          = 300000
 	defaultHubDenom          = "adym"
 	defaultGasFees           = "100000000000000000" + defaultHubDenom
-	defaultMinimumGasBalance = "40000000000" + defaultHubDenom
+	defaultMinimumGasBalance = "1000000000000000000" + defaultHubDenom
 	testKeyringBackend       = "test"
 
 	botNamePrefix               = "bot-"

--- a/config.go
+++ b/config.go
@@ -68,7 +68,7 @@ const (
 	defaultLogLevel          = "info"
 	defaultGasLimit          = 300000
 	defaultHubDenom          = "adym"
-	defaultGasFees           = "100000000000000000" + defaultHubDenom
+	defaultGasFees           = "3000000000000000" + defaultHubDenom
 	defaultMinimumGasBalance = "1000000000000000000" + defaultHubDenom
 	testKeyringBackend       = "test"
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Updates**
	- Adjusted the default minimum gas balance from `40,000,000,000 adym` to `1,000,000,000,000,000,000 adym` to better support transaction processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->