### PR TITLE
feat: fee rule functionality

### DIFF
--- a/config.go
+++ b/config.go
@@ -17,8 +17,9 @@ type Config struct {
 	Gas          GasConfig          `mapstructure:"gas"`
 	OrderPolling OrderPollingConfig `mapstructure:"order_polling"`
 
-	Whale whaleConfig `mapstructure:"whale"`
-	Bots  botConfig   `mapstructure:"bots"`
+	Whale           whaleConfig     `mapstructure:"whale"`
+	Bots            botConfig       `mapstructure:"bots"`
+	FulfillCriteria fulfillCriteria `mapstructure:"fulfill_criteria"`
 
 	LogLevel    string      `mapstructure:"log_level"`
 	SlackConfig slackConfig `mapstructure:"slack"`
@@ -50,6 +51,15 @@ type whaleConfig struct {
 	KeyringBackend           cosmosaccount.KeyringBackend `mapstructure:"keyring_backend"`
 	KeyringDir               string                       `mapstructure:"keyring_dir"`
 	AllowedBalanceThresholds map[string]string            `mapstructure:"allowed_balance_thresholds"`
+}
+
+type fulfillCriteria struct {
+	MinFeePercentage minFeePercentage `mapstructure:"min_fee_percentage"`
+}
+
+type minFeePercentage struct {
+	Chain map[string]float32 `mapstructure:"chain"`
+	Asset map[string]float32 `mapstructure:"asset"`
 }
 
 type slackConfig struct {

--- a/order_fulfiller.go
+++ b/order_fulfiller.go
@@ -181,7 +181,7 @@ func (ol *orderFulfiller) fulfillDemandOrders(demandOrder ...*demandOrder) error
 	msgs := make([]sdk.Msg, len(demandOrder))
 
 	for i, order := range demandOrder {
-		msgs[i] = types.NewMsgFulfillOrder(ol.accountSvc.account.GetAddress().String(), order.id, order.fee)
+		msgs[i] = types.NewMsgFulfillOrder(ol.accountSvc.account.GetAddress().String(), order.id, order.fee.String())
 	}
 
 	_, err := ol.client.BroadcastTx(ol.accountSvc.accountName, msgs...)

--- a/order_poller.go
+++ b/order_poller.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/cosmos/ibc-go/v6/modules/apps/transfer/types"
 	"github.com/dymensionxyz/cosmosclient/cosmosclient"
 	"go.uber.org/zap"
 )
@@ -24,46 +23,44 @@ type orderPoller struct {
 	indexerClient *http.Client
 	logger        *zap.Logger
 
-	batchSize int
-	newOrders chan []*demandOrder
-	tracker   *orderTracker
+	batchSize       int
+	newOrders       chan []*demandOrder
+	canFulfillOrder func(*demandOrder) bool
 	sync.Mutex
 	pathMap map[string]string
 }
 
 func newOrderPoller(
 	client cosmosclient.Client,
-	tracker *orderTracker,
+	canFulfillOrder func(*demandOrder) bool,
 	pollingCfg OrderPollingConfig,
 	batchSize int,
 	newOrders chan []*demandOrder,
 	logger *zap.Logger,
 ) *orderPoller {
 	return &orderPoller{
-		client:        client,
-		indexerURL:    pollingCfg.IndexerURL,
-		interval:      pollingCfg.Interval,
-		batchSize:     batchSize,
-		logger:        logger.With(zap.String("module", "order-poller")),
-		newOrders:     newOrders,
-		tracker:       tracker,
-		pathMap:       make(map[string]string),
-		indexerClient: &http.Client{Timeout: 25 * time.Second},
+		client:          client,
+		indexerURL:      pollingCfg.IndexerURL,
+		interval:        pollingCfg.Interval,
+		batchSize:       batchSize,
+		logger:          logger.With(zap.String("module", "order-poller")),
+		newOrders:       newOrders,
+		canFulfillOrder: canFulfillOrder,
+		pathMap:         make(map[string]string),
+		indexerClient:   &http.Client{Timeout: 25 * time.Second},
 	}
 }
 
 const (
-	ordersQuery = `{"query": "{ibcTransferDetails(filter: {network: {equalTo: \"%s\"} status: {equalTo: EibcPending}}) {nodes { eibcOrderId denom amount destinationChannel time }}}"}`
+	ordersQuery = `{"query": "{ibcTransferDetails(filter: {network: {equalTo: \"%s\"} status: {equalTo: EibcPending}}) {nodes { eibcOrderId amount destinationChannel blockHeight rollappId eibcFee }}}"}`
 )
 
 type Order struct {
-	EibcOrderId        string `json:"eibcOrderId"`
-	Denom              string `json:"denom"`
-	Amount             string `json:"amount"`
-	Fee                string `json:"fee"`
-	DestinationChannel string `json:"destinationChannel"`
-	Time               string `json:"time"`
-	time               time.Time
+	EibcOrderId string `json:"eibcOrderId"`
+	Amount      string `json:"amount"`
+	Fee         string `json:"eibcFee"`
+	RollappId   string `json:"rollappId"`
+	BlockHeight string `json:"blockHeight"`
 }
 
 type ordersResponse struct {
@@ -81,7 +78,7 @@ func (p *orderPoller) start(ctx context.Context) {
 			case <-ctx.Done():
 				return
 			default:
-				if err := p.pollPendingDemandOrders(ctx); err != nil {
+				if err := p.pollPendingDemandOrders(); err != nil {
 					p.logger.Error("failed to refresh demand orders", zap.Error(err))
 				}
 			}
@@ -89,66 +86,89 @@ func (p *orderPoller) start(ctx context.Context) {
 	}()
 }
 
-func (p *orderPoller) pollPendingDemandOrders(ctx context.Context) error {
-	p.logger.Debug("refreshing demand orders")
-
-	orders, err := p.getDemandOrdersFromIndexer(ctx)
+func (p *orderPoller) pollPendingDemandOrders() error {
+	demandOrders, err := p.getDemandOrdersFromIndexer()
 	if err != nil {
 		return fmt.Errorf("failed to get demand orders: %w", err)
 	}
 
-	unfulfilledOrders := make([]*demandOrder, 0, len(orders))
-
-	for _, d := range orders {
-		if !p.tracker.canFulfillOrder(d.EibcOrderId, d.Denom) {
-			continue
-		}
-
-		amountStr := fmt.Sprintf("%s%s", d.Amount, d.Denom)
-
-		totalAmount, err := sdk.ParseCoinNormalized(amountStr)
-		if err != nil {
-			p.logger.Error("failed to parse amount", zap.Error(err))
-			continue
-		}
-		order := &demandOrder{
-			id:     d.EibcOrderId,
-			amount: sdk.NewCoins(totalAmount),
-			fee:    d.Fee,
-		}
-		unfulfilledOrders = append(unfulfilledOrders, order)
-	}
-
-	if len(unfulfilledOrders) == 0 {
-		return nil
-	}
-
-	ids := make([]string, 0, len(unfulfilledOrders))
-	for _, order := range unfulfilledOrders {
-		ids = append(ids, order.id)
-	}
-
-	if p.logger.Level() <= zap.DebugLevel {
-		p.logger.Debug("new demand orders", zap.Strings("count", ids))
-	} else {
-		p.logger.Info("new demand orders", zap.Int("count", len(ids)))
-	}
-
+	orders := p.convertOrders(demandOrders)
 	batch := make([]*demandOrder, 0, p.batchSize)
+	ids := make([]string, 0, len(orders))
 
-	for _, order := range unfulfilledOrders {
+	for _, order := range orders {
 		batch = append(batch, order)
+		ids = append(ids, order.id)
 
-		if len(batch) >= p.batchSize || len(batch) == len(unfulfilledOrders) {
+		if len(batch) >= p.batchSize || len(batch) == len(orders) {
 			p.newOrders <- batch
 			batch = make([]*demandOrder, 0, p.batchSize)
+			ids = make([]string, 0, len(orders))
+
+			if p.logger.Level() <= zap.DebugLevel {
+				p.logger.Debug("new orders batch", zap.Strings("count", ids))
+			} else {
+				p.logger.Info("new orders batch", zap.Int("count", len(ids)))
+			}
 		}
 	}
 
 	return nil
 }
 
-func (p *orderPoller) getDemandOrdersFromIndexer(ctx context.Context) ([]Order, error) {
+func (p *orderPoller) convertOrders(demandOrders []Order) (orders []*demandOrder) {
+	for _, order := range demandOrders {
+		if order.Fee == "" {
+			p.logger.Warn("order fee is empty", zap.String("order", order.EibcOrderId))
+			continue
+		}
+
+		fee, err := sdk.ParseCoinsNormalized(order.Fee)
+		if err != nil {
+			p.logger.Error("failed to parse fee", zap.Error(err))
+			continue
+		}
+
+		denom := fee.GetDenomByIndex(0)
+
+		amountStr := fmt.Sprintf("%s%s", order.Amount, denom)
+		amount, err := sdk.ParseCoinsNormalized(amountStr)
+		if err != nil {
+			p.logger.Error("failed to parse amount", zap.Error(err))
+			continue
+		}
+
+		blockHeight, err := strconv.ParseUint(order.BlockHeight, 10, 64)
+		if err != nil {
+			p.logger.Error("failed to parse block height", zap.Error(err))
+			continue
+		}
+
+		newOrder := &demandOrder{
+			id:          order.EibcOrderId,
+			amount:      amount,
+			fee:         fee,
+			denom:       denom,
+			rollappId:   order.RollappId,
+			blockHeight: blockHeight,
+		}
+
+		if !p.canFulfillOrder(newOrder) {
+			continue
+		}
+
+		orders = append(orders, newOrder)
+	}
+
+	sort.Slice(orders, func(i, j int) bool {
+		return orders[i].blockHeight < orders[j].blockHeight
+	})
+	return orders
+}
+
+func (p *orderPoller) getDemandOrdersFromIndexer() ([]Order, error) {
+	p.logger.Debug("getting demand orders from indexer")
+
 	queryStr := fmt.Sprintf(ordersQuery, p.client.Context().ChainID)
 	body := strings.NewReader(queryStr)
 
@@ -166,90 +186,5 @@ func (p *orderPoller) getDemandOrdersFromIndexer(ctx context.Context) ([]Order, 
 		return nil, fmt.Errorf("failed to decode response: %w", err)
 	}
 
-	var orders []Order
-
-	// parse the time format of "1714742916108" into time.Time and sort by time
-	for _, order := range res.Data.IbcTransferDetails.Nodes {
-		if order.Time == "" {
-			continue
-		}
-
-		timeUnix, err := strconv.ParseInt(order.Time, 10, 64)
-		if err != nil {
-			p.logger.Error("failed to parse time", zap.Error(err))
-			continue
-		}
-
-		denom, err := p.getDenomFromPath(ctx, order.Denom, order.DestinationChannel)
-		if err != nil {
-			p.logger.Error("failed to get denom hash", zap.String("d.Denom", order.Denom), zap.Error(err))
-			continue
-		}
-
-		if order.Fee == "" {
-			p.logger.Warn("order fee is empty", zap.String("order", order.EibcOrderId))
-			continue
-		}
-
-		newOrder := Order{
-			EibcOrderId:        order.EibcOrderId,
-			Denom:              denom,
-			Amount:             order.Amount,
-			Fee:                order.Fee,
-			DestinationChannel: order.DestinationChannel,
-			Time:               order.Time,
-			time:               time.Unix(timeUnix/1000, (timeUnix%1000)*int64(time.Millisecond)),
-		}
-
-		orders = append(orders, newOrder)
-	}
-
-	// sort by time
-	sort.Slice(orders, func(i, j int) bool {
-		return orders[i].time.Before(orders[j].time)
-	})
-
-	return orders, nil
-}
-
-func (p *orderPoller) getDenomFromPath(ctx context.Context, path, destChannel string) (string, error) {
-	zeroChannelPrefix := "transfer/channel-0/"
-
-	// Remove "transfer/channel-0/" prefix if it exists
-	path = strings.TrimPrefix(path, zeroChannelPrefix)
-
-	if path == defaultHubDenom {
-		return defaultHubDenom, nil
-	}
-
-	// for denoms other than adym we should have a full path
-	// in order to be albe to derive the ibc denom hash
-	if !strings.Contains(path, "channel-") {
-		path = fmt.Sprintf("transfer/%s/%s", destChannel, path)
-	}
-
-	p.Lock()
-	defer p.Unlock()
-
-	denom, ok := p.pathMap[path]
-	if ok {
-		return denom, nil
-	}
-
-	queryClient := types.NewQueryClient(p.client.Context())
-
-	req := &types.QueryDenomHashRequest{
-		Trace: path,
-	}
-
-	res, err := queryClient.DenomHash(ctx, req)
-	if err != nil {
-		return "", fmt.Errorf("failed to query denom hash: %w", err)
-	}
-
-	ibcDenom := fmt.Sprintf("ibc/%s", res.Hash)
-
-	p.pathMap[path] = ibcDenom
-
-	return ibcDenom, nil
+	return res.Data.IbcTransferDetails.Nodes, nil
 }

--- a/order_tracker_test.go
+++ b/order_tracker_test.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+func Test_orderTracker_canFulfillOrder(t *testing.T) {
+	type fields struct {
+		currentOrders   map[string]struct{}
+		trackedOrders   map[string]struct{}
+		fulfillCriteria *fulfillCriteria
+	}
+	type args struct {
+		order *demandOrder
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   bool
+	}{
+		{
+			name: "can fulfill order",
+			fields: fields{
+				fulfillCriteria: &fulfillCriteria{
+					MinFeePercentage: sampleMinFeePercentage,
+				},
+			},
+			args: args{
+				order: sampleDemandOrder,
+			},
+			want: true,
+		}, {
+			name: "cannot fulfill order: order already fulfilled",
+			fields: fields{
+				trackedOrders: map[string]struct{}{
+					sampleDemandOrder.id: {},
+				},
+				fulfillCriteria: &fulfillCriteria{
+					MinFeePercentage: sampleMinFeePercentage,
+				},
+			},
+			args: args{
+				order: sampleDemandOrder,
+			},
+			want: false,
+		}, {
+			name: "cannot fulfill order: order already being processed",
+			fields: fields{
+				currentOrders: map[string]struct{}{
+					sampleDemandOrder.id: {},
+				},
+				fulfillCriteria: &fulfillCriteria{
+					MinFeePercentage: sampleMinFeePercentage,
+				},
+			},
+			args: args{
+				order: sampleDemandOrder,
+			},
+			want: false,
+		}, {
+			name: "cannot fulfill order: asset fee percentage is lower than minimum",
+			fields: fields{
+				fulfillCriteria: &fulfillCriteria{
+					MinFeePercentage: minFeePercentage{
+						Asset: map[string]float32{
+							sampleDemandOrder.denom: 0.2,
+						},
+						Chain: map[string]float32{
+							sampleDemandOrder.rollappId: 0.1,
+						},
+					},
+				},
+			},
+			args: args{
+				order: sampleDemandOrder,
+			},
+			want: false,
+		}, {
+			name: "cannot fulfill order: chain fee percentage is lower than minimum",
+			fields: fields{
+				fulfillCriteria: &fulfillCriteria{
+					MinFeePercentage: minFeePercentage{
+						Asset: map[string]float32{
+							sampleDemandOrder.denom: 0.1,
+						},
+						Chain: map[string]float32{
+							sampleDemandOrder.rollappId: 0.2,
+						},
+					},
+				},
+			},
+			args: args{
+				order: sampleDemandOrder,
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			or := &orderTracker{
+				currentOrders:   tt.fields.currentOrders,
+				trackedOrders:   tt.fields.trackedOrders,
+				fulfillCriteria: tt.fields.fulfillCriteria,
+			}
+			if or.currentOrders == nil {
+				or.currentOrders = make(map[string]struct{})
+			}
+			if or.trackedOrders == nil {
+				or.trackedOrders = make(map[string]struct{})
+			}
+			if got := or.canFulfillOrder(tt.args.order); got != tt.want {
+				t.Errorf("canFulfillOrder() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+var (
+	sampleMinFeePercentage = minFeePercentage{
+		Asset: map[string]float32{
+			sampleDemandOrder.denom: 0.1,
+		},
+		Chain: map[string]float32{
+			sampleDemandOrder.rollappId: 0.1,
+		},
+	}
+
+	sampleDemandOrder = &demandOrder{
+		id:        "order1",
+		amount:    amount,
+		fee:       fee,
+		denom:     amount.GetDenomByIndex(0),
+		rollappId: "rollappId",
+	}
+
+	amount, _ = sdk.ParseCoinsNormalized("10526097010000000000denom")
+	fee, _    = sdk.ParseCoinsNormalized("15789145514999998denom")
+)

--- a/types.go
+++ b/types.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"math/big"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
@@ -10,10 +12,34 @@ type orderBatch struct {
 }
 
 type demandOrder struct {
-	id     string
-	amount sdk.Coins
-	fee    string
-	status string
+	id          string
+	denom       string
+	amount      sdk.Coins
+	fee         sdk.Coins
+	rollappId   string
+	status      string
+	blockHeight uint64
+}
+
+func (o *demandOrder) feePercentage() float32 {
+	amount := o.amount.AmountOf(o.denom)
+	if amount.IsZero() {
+		return 0
+	}
+
+	price, _, err := big.ParseFloat(amount.String(), 10, 64, big.ToNearestEven)
+	if err != nil {
+		panic(err)
+	}
+
+	fee, _, err := big.ParseFloat(o.fee.AmountOf(o.denom).String(), 10, 64, big.ToNearestEven)
+	if err != nil {
+		panic(err)
+	}
+
+	feeProportion, _ := new(big.Float).Quo(fee, price).Float32()
+	feePercent := feeProportion * 100
+	return feePercent
 }
 
 type account struct {


### PR DESCRIPTION
This section will be added to the config file:

```
fulfill_criteria:
    min_fee_percentage:
        chain:
            rollapp_1234-1: 0.12
            rollapp_1234-2: 0.14
        asset:
            adym: 0.13
            ibc/5a26c8dc8da66f4dd94326e67f94510188f5f7afe2db3933a0c823670e56eabf: 0.15
            ibc/9A1EACD53A6A197ADC81DF9A49F0C4A26F7FF685ACF415EE726D7D59796E71A7: 0.14
```

The chains and assets mapped there will also act as a whitelist for order rollappIDs and denoms.

Closes #34 and #37