### PR TITLE
Makefile incorrect mv operation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ all: install
 .PHONY: install
 install: build
 	@echo "--> installing eibc-client"
-	mv build/eibc $(GOPATH)/bin/eibc-client
+	mv build/eibc-client $(GOPATH)/bin/eibc-client
 
 .PHONY: build
 build: go.sum ## Compiles the eibc binary


### PR DESCRIPTION
This small PR patches the Makefile to ensure correct path when running `make install`